### PR TITLE
Fix loading of iCloud data.

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -264,7 +264,7 @@ module.exports = NodeHelper.create({
           body: '{"streamCtag":null}'
         });
       } else if (response.statusCode === 200) {
-        var photos = shuffle(body.photos).slice(0, config.maximumEntries);
+        var photos = shuffle(body.photos).filter((p) => p != null).slice(0, config.maximumEntries);
         var photoGuids = photos.map((p) => { return p.photoGuid; });
 
         self.iCloudState = "webasseturls";
@@ -285,7 +285,7 @@ module.exports = NodeHelper.create({
         }, {});
 
         self.request(config, {
-          mthod: "POST",
+          method: "POST",
           url: fmt("https://{}/{}/sharedstreams/webasseturls", self.iCloudHost, album),
           body: JSON.stringify({"photoGuids": photoGuids}),
         });


### PR DESCRIPTION
This change fixes some issues found when trying to use `source: "icloud:<album id>"`. The two issues found were:
- The initial call to iCloud can include`photos[]` with an `undefined` value (deleted or hidden photo case?).
- Follow-on request to retrieve image metadata was malformed and could never succeed.