### PR TITLE
add multireddit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ The following properties can be configured:
 |`"icloud:<album id>"`|Cycles through random selections of the specified album.|
 |`"lightroom:<user.myportfolio.com/album>"`|Cycles through random selections of the specified album.|
 |`"/r/<subreddit>"`|Cycles through the most recent `hot` image posts from the subreddit.|
+|`"/user/<username>/m/<subreddit>"`|Cycles through the most recent `hot` image posts from the your multireddit.|

--- a/node_helper.js
+++ b/node_helper.js
@@ -89,6 +89,13 @@ module.exports = NodeHelper.create({
           "user-agent": "MagicMirror:MMM-Wallpaper:v1.0 (by /u/kolbyhack)"
         },
       });
+      else if (source.startsWith("/user/")) {
+      self.request(config, {
+        url: `https://www.reddit.com${config.source}/hot.json`,
+        headers: {
+          "user-agent": "MagicMirror:MMM-Wallpaper:v1.0 (by /u/kolbyhack)"
+        },
+      });
     } else if (source === "pexels") {
       self.request(config, {
         url: "https://api.pexels.com/v1/search?query=" + config.pexels_search,

--- a/node_helper.js
+++ b/node_helper.js
@@ -89,9 +89,9 @@ module.exports = NodeHelper.create({
           "user-agent": "MagicMirror:MMM-Wallpaper:v1.0 (by /u/kolbyhack)"
         },
       });
-      else if (source.startsWith("/user/")) {
+    } else if (source.startsWith("/user/")) {
       self.request(config, {
-        url: `https://www.reddit.com${config.source}/hot.json`,
+        url: `https://www.reddit.com${config.source}.json`,
         headers: {
           "user-agent": "MagicMirror:MMM-Wallpaper:v1.0 (by /u/kolbyhack)"
         },
@@ -175,7 +175,7 @@ module.exports = NodeHelper.create({
     var images;
 
     var source = config.source.toLowerCase();
-    if (source.startsWith("/r/")) {
+    if (source.startsWith("/r/") || source.startsWith("/user/")) {
       images = self.processRedditData(config, JSON.parse(body));
     } else if (source.startsWith("icloud:")) {
       images = self.processiCloudData(response, JSON.parse(body), config);


### PR DESCRIPTION
- add code to node_helper to allow user multireddits
- update readme to reflect changes

Alllows the user to add a multireddit they have created. I only tested it with public multireddits. Could probably reword/refactor it to make it a little easier for the end user.