### PR TITLE
Reuse the same module to display images that are not wallpapers. Adde…

### DIFF
--- a/MMM-Wallpaper.css
+++ b/MMM-Wallpaper.css
@@ -29,3 +29,9 @@
   font-size: 14px;
   line-height: 25px;
 }
+
+.MMM-Wallpaper .content_image {
+}
+
+.MMM-Wallpaper .title_image {
+}

--- a/MMM-Wallpaper.js
+++ b/MMM-Wallpaper.js
@@ -19,6 +19,7 @@ Module.register("MMM-Wallpaper", {
     shuffle: true,
     addCacheBuster: true,
     userPresenceAction: "none",
+    wallpaper: true,
   },
 
   getStyles: function() {
@@ -44,6 +45,11 @@ Module.register("MMM-Wallpaper", {
 
     self.content.className = "content";
     self.title.className = "title";
+    
+    if(!self.config.wallpaper) {
+      self.content.className += "_image";
+      self.title.className += "_image";
+    }
 
     self.getData();
     self.updateTimer = setInterval(() => self.getData(), self.config.updateInterval);
@@ -116,7 +122,9 @@ Module.register("MMM-Wallpaper", {
     var self = this;
 
     return () => {
-      img.className = `wallpaper ${self.config.crossfade ? "crossfade-image" : ""}`;
+      img.className = self.config.wallpaper ? "wallpaper" : "image";
+			img.className += self.config.crossfade ? " crossfade-image" : "";
+
       img.style["object-fit"] = self.config.size;
       img.style.opacity = 1;
       self.title.style.display = "none";
@@ -159,10 +167,21 @@ Module.register("MMM-Wallpaper", {
     var e = document.documentElement;
     var g = document.body;
 
-    return {
-      width: w.innerWidth || e.clientWidth || g.clientWidth,
-      height: w.innerHeight || e.clientHeight || g.clientHeight
-    };
+    if(!self.config) {
+      return {width:1, height:1};
+    }
+
+    if(self.config.wallpaper) {
+      return {
+        width: w.innerWidth || e.clientWidth || g.clientWidth,
+        height: w.innerHeight || e.clientHeight || g.clientHeight
+      };
+    } else {
+      return {
+        width: self.content.clientWidth,
+        height: self.content.clientHeight
+      };
+    }
   },
 
   getImageUrl: function(image) {


### PR DESCRIPTION
Reuse the same module to display images that are not wallpapers. Added a new config param to select if the module is used as wallpaper or simple image.

See usage example in the attached image. The module is used for both the wallpaper and the bottom left image. It's pulling images from a web server where I have security cameras. It's pulling every 2 seconds. 

![Library - 1 of 1](https://user-images.githubusercontent.com/400709/149036375-b4a9a389-6c85-412d-ab7a-a3e4368c1c5a.jpeg)

My configuration for this double use: 

```
{
	module: "MMM-Wallpaper",
	position: "fullscreen_below",
	config: { // See "Configuration options" for more information.
		source: "http://localhost:1080/Mountain?crop=144,130,2700,1520",
		updateInterval: 10 * 1000,
		filter: "none",
		addCacheBuster: true,
		crossfade: false,
		wallpaper: true,
	}
},
{
	module: "MMM-Wallpaper",
	position: "bottom_left",
	config: { // See "Configuration options" for more information.
		source: "http://localhost:1080/FrontDoor?crop=0,0,460,360&rotate=270",
		updateInterval: 10 * 1000,
		filter: "none",
		addCacheBuster: true,
		crossfade: false,
		wallpaper: false,
	}
},
```

The wallpaper uses is still the default one and should work as before. For the new image use, you need to set `wallpaper: false` in the config file. 
