### PR TITLE
Fixing MetMuseum images

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -150,7 +150,7 @@ module.exports = NodeHelper.create({
     } else if (source.startsWith("metmuseum:")) {
       var args = config.source.substring(10).split(",");
       self.request(config, {
-        url: `https://collectionapi.metmuseum.org/public/collection/v1/search?hasImages=true&departmentId=${args[0]}&isHighlight=${args[1]}&q=${args[2]}`,
+        url: `https://collectionapi.metmuseum.org/public/collection/v1/search?hasImages=true&departmentIds=${args[0]}&isHighlight=${args[1]}&q=${args[2]}`,
       });
     } else if (source.startsWith("nasa:")) {
       const searchTerm = config.source.split(":")[1];

--- a/node_helper.js
+++ b/node_helper.js
@@ -149,9 +149,13 @@ module.exports = NodeHelper.create({
       });
     } else if (source.startsWith("metmuseum:")) {
       var args = config.source.substring(10).split(",");
-      self.request(config, {
-        url: `https://collectionapi.metmuseum.org/public/collection/v1/search?hasImages=true&departmentIds=${args[0]}&isHighlight=${args[1]}&q=${args[2]}`,
-      });
+      var departments = args[0].split('|');
+      for (var i = 0; i < departments.length; i++) {
+        var departmentId = departments[i];
+        self.request(config, {
+          url: `https://collectionapi.metmuseum.org/public/collection/v1/search?hasImages=true&departmentId=${departmentId}&isHighlight=${args[1]}&q=${args[2]}`,
+        });
+      }
     } else if (source.startsWith("nasa:")) {
       const searchTerm = config.source.split(":")[1];
       if (!searchTerm || searchTerm.length === 0 || searchTerm === "") {

--- a/node_helper.js
+++ b/node_helper.js
@@ -582,7 +582,7 @@ module.exports = NodeHelper.create({
 
           if (obj.isPublicDomain) {
             const image = {
-              url: obj.primaryImageSmall,
+              url: obj.primaryImage,
               caption: `${obj.title} - ${obj.artistDisplayName}`,
             };
 
@@ -605,7 +605,7 @@ module.exports = NodeHelper.create({
       req.end();
     }
 
-    return [];
+    return images;
   },
 
   /* NASA APIs documented under https://api.nasa.gov/.


### PR DESCRIPTION
Thing fixed:

1. Looping through all departments to make sure we query those - note, API doesn't accept multi-value ids.
2. Either we're missing a dependency, but metmuseums uses request - which doesn't exist, instead I switched to https.request.
3. Return the images.

For now, it takes some time to process these, as it's many request (in my case with 30 images, it's roughly 30s or so) - but images do actually load now ^_^