### PR TITLE
Support for multiple Flickr sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ flickr-api:
 |---|---|---|
 |`"flickrApiKey"`|`none`|Sign up for an [api key](https://www.flickr.com/services/apps/create/noncommercial/) and enter it here. (Required)|
 
+*Notes:*
+* You can specify multiple Flickr sources separated by `;`. For example: `flickr-api:publicPhotos;photos/<user1>/favorites;photos/<user2>/favorites`
+  * If `shuffle` is `true`, up to `maximumEntries` will be listed from each source, then shuffled and no more than `maximumEntries` presented.
+  * If `shuffle` is `false`, up to `maximumEntries` photos will be presented from the sources in order.
+* Flickr limits usage by a single API key to 3600 queries per hour. If you set a very high `maximumEntries` you may run into this limit. This module makes the following Flickr API calls every `updateInterval`:
+  * At least 1 call to `getPublicPhotos` per configured source (each call returns up to 500 photos; if there are more, and you've set `maximumEntries` higher, there will be further calls)
+  * 1 call to `getSizes` per photo selected for display (at most `maximumEntries`)
+
+
 |Source|Description|
 |---|---|
 |`publicPhotos`|Loads unfiltered public content.|

--- a/node_helper.js
+++ b/node_helper.js
@@ -642,6 +642,11 @@ module.exports = NodeHelper.create({
       self.flickrFeeds = new Flickr.Feeds();
     }
 
+    self.fetchOneFlickrSource(config, args);
+  },
+
+  fetchOneFlickrSource: function(config, args) {
+    const self = this;
     if (args[0] === "publicPhotos") {
       self.flickrFeeds.publicPhotos().then(res => {
         self.processFlickrFeedPhotos(config, res.body.items);

--- a/node_helper.js
+++ b/node_helper.js
@@ -657,8 +657,8 @@ module.exports = NodeHelper.create({
       if (config.shuffle) {
         images = shuffle(images);
       }
-      self.cacheResult(config, images);
-    });
+      return images.slice(0, config.maximumEntries);
+    }).then((images) => self.cacheResult(config, images));
   },
 
   fetchOneFlickrSource: function(config, args, resolve) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -648,9 +648,14 @@ module.exports = NodeHelper.create({
       promises.push(new Promise((resolve, reject) => self.fetchOneFlickrSource(config, args, resolve)));
     }
     Promise.all(promises).then((results) => {
-      const images = [];
+      let images = [];
       for (const result of results) {
         images.push(...result);
+      }
+      // Each source fetches up to maximumImages images (in case some have fewer).
+      // Apply shuffle now, as the consumer will truncate.
+      if (config.shuffle) {
+        images = shuffle(images);
       }
       self.cacheResult(config, images);
     });

--- a/node_helper.js
+++ b/node_helper.js
@@ -658,6 +658,8 @@ module.exports = NodeHelper.create({
         images = shuffle(images);
       }
       return images.slice(0, config.maximumEntries);
+    }).then((images) => {
+      return new Promise((resolve, reject) => self.processFlickrPhotos(config, images, resolve));
     }).then((images) => self.cacheResult(config, images));
   },
 
@@ -727,26 +729,25 @@ module.exports = NodeHelper.create({
 
     args.per_page = args.per_page || config.maximumEntries;
     source.getPhotos(args).then(res => {
-      self.processFlickrPhotos(config, res.body[resultType].photo.map(p => {
+      resolve(res.body[resultType].photo.map(p => {
         return {
           id: p.id,
           title: p.title,
           owner: p.ownername,
         }
-      }), resolve);
+      }));
     });
   },
 
   processFlickrFeedPhotos: function(config, items, resolve) {
     const self = this;
-
-    self.processFlickrPhotos(config, items.map(i => {
+    resolve(items.map(i => {
       return {
         id: i.link.split("/").filter(s => s.length > 0).slice(-1)[0],
         title: i.title,
         owner: i.author.split('"').filter(s => s.length > 0).slice(-2)[0],
       }
-    }), resolve);
+    }));
   },
 
   processFlickrPhotos: function(config, photos, resolve) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -762,14 +762,19 @@ module.exports = NodeHelper.create({
         }
 
         if (--pendingRequests === 0) {
-          self.cacheResult(config, images);
+          self.handleCompletedFlickrPhotos(config, images);
         }
       }).catch(err => {
         if (--pendingRequests === 0) {
-          self.cacheResult(config, images);
+          self.handleCompletedFlickrPhotos(config, images);
         }
       });
     }
+  },
+
+  handleCompletedFlickrPhotos: function (config, images) {
+    var self = this;
+    self.cacheResult(config, images);
   },
 
   getCacheEntry: function(config) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -657,7 +657,7 @@ module.exports = NodeHelper.create({
       if (config.shuffle) {
         images = shuffle(images);
       }
-      return images.slice(0, config.maximumEntries);
+      return images; // processFlickrPhotos truncates the array to maximumEntries
     }).then((images) => {
       return new Promise((resolve, reject) => self.processFlickrPhotos(config, images, resolve));
     }).then((images) => self.cacheResult(config, images));
@@ -754,7 +754,7 @@ module.exports = NodeHelper.create({
     const self = this;
     const images = [];
 
-    photos = photos.slice(0, Math.max(60, config.maximumEntries));
+    photos = photos.slice(0, config.maximumEntries);
     let pendingRequests = photos.length;
 
     for (let p of photos) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -644,8 +644,7 @@ module.exports = NodeHelper.create({
 
     const promises = [];
     for (const source of sources) {
-      const args = source.split('/').filter(s => s.length > 0);
-      promises.push(new Promise((resolve, reject) => self.fetchOneFlickrSource(config, args, resolve)));
+      promises.push(new Promise((resolve, reject) => self.fetchOneFlickrSource(config, source, resolve)));
     }
     Promise.all(promises).then((results) => {
       let images = [];
@@ -663,8 +662,9 @@ module.exports = NodeHelper.create({
     }).then((images) => self.cacheResult(config, images));
   },
 
-  fetchOneFlickrSource: function(config, args, resolve) {
+  fetchOneFlickrSource: function(config, source, resolve) {
     const self = this;
+    const args = source.split('/').filter(s => s.length > 0);
     if (args[0] === "publicPhotos") {
       self.flickrFeeds.publicPhotos().then(res => {
         self.processFlickrFeedPhotos(config, res.body.items, resolve);
@@ -716,6 +716,9 @@ module.exports = NodeHelper.create({
           extras: "owner_name",
         }, resolve);
       });
+    } else {
+      console.warn(`Unrecognised Flickr source ${source}, ignoring`);
+      resolve([]);
     }
   },
 


### PR DESCRIPTION
This changeset expands the `flickr-api:` source syntax to support multiple Flickr sources (separated by `;` though there might be a reason to prefer some other delimiter).

I have a further branch [feature/cache-flickr-sizes](https://github.com/crazyscot/MMM-Wallpaper/tree/feature/cache-flickr-sizes) that reduces API load by cacheing the `getSizes` results. I will PR that separately (it is dependent on this one, as things stand).