### PR TITLE
Cache Flickr image size data, reduce bandwidth use

### DIFF
--- a/MMM-Wallpaper.js
+++ b/MMM-Wallpaper.js
@@ -22,6 +22,7 @@ Module.register("MMM-Wallpaper", {
     width: "auto",
     height: "auto",
     flickrApiKey: "",
+    flickrDataCacheTime: 24 * 60 * 60 * 1000,
     fadeEdges: false,
   },
 

--- a/MMM-Wallpaper.js
+++ b/MMM-Wallpaper.js
@@ -23,6 +23,7 @@ Module.register("MMM-Wallpaper", {
     height: "auto",
     flickrApiKey: "",
     flickrDataCacheTime: 24 * 60 * 60 * 1000,
+    flickrResultsPerPage: 500, // Flickr API is limited to 500 photos per page
     fadeEdges: false,
   },
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ flickr-api:
 |---|---|---|
 |`"flickrApiKey"`|`none`|Sign up for an [api key](https://www.flickr.com/services/apps/create/noncommercial/) and enter it here. (Required)|
 |`"flickrDataCacheTime"`| `24*60*60*3600` (1 day) | How long to cache image metadata retrieved from Flickr. |
+|`"flickrResultsPerPage"`| `500` | How photo results per page to request from the Flickr API |
 
 *Notes:*
 * You can specify multiple Flickr sources separated by `;`. For example: `flickr-api:publicPhotos;photos/<user1>/favorites;photos/<user2>/favorites`

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ flickr-api:
 |Option|Default|Description|
 |---|---|---|
 |`"flickrApiKey"`|`none`|Sign up for an [api key](https://www.flickr.com/services/apps/create/noncommercial/) and enter it here. (Required)|
+|`"flickrDataCacheTime"`| `24*60*60*3600` (1 day) | How long to cache image metadata retrieved from Flickr. |
 
 *Notes:*
 * You can specify multiple Flickr sources separated by `;`. For example: `flickr-api:publicPhotos;photos/<user1>/favorites;photos/<user2>/favorites`
@@ -102,7 +103,7 @@ flickr-api:
   * If `shuffle` is `false`, up to `maximumEntries` photos will be presented from the sources in order.
 * Flickr limits usage by a single API key to 3600 queries per hour. If you set a very high `maximumEntries` you may run into this limit. This module makes the following Flickr API calls every `updateInterval`:
   * At least 1 call to `getPublicPhotos` per configured source (each call returns up to 500 photos; if there are more, and you've set `maximumEntries` higher, there will be further calls)
-  * 1 call to `getSizes` per photo selected for display (at most `maximumEntries`)
+  * 1 call to `getSizes` per photo selected for display (at most `maximumEntries`); the results are cached for `flickrDataCacheTime`.
 
 
 |Source|Description|

--- a/node_helper.js
+++ b/node_helper.js
@@ -670,13 +670,16 @@ module.exports = NodeHelper.create({
     const self = this;
     const args = source.split('/').filter(s => s.length > 0);
     if (args[0] === "publicPhotos") {
-      self.flickrFeeds.publicPhotos().then(res => {
+      self.flickrFeeds.publicPhotos({
+        per_page: config.flickrResultsPerPage,
+      }).then(res => {
         self.processFlickrFeedPhotos(config, res.body.items, resolve);
       });
     } else if (args[0] === "tags" && args.length > 1) {
       self.flickrFeeds.publicPhotos({
         tags: args[1],
         tagmode: (args.length > 2) ? args[2] : "all",
+        per_page: config.flickrResultsPerPage,
       }).then(res => {
         self.processFlickrFeedPhotos(config, res.body.items, resolve);
       });
@@ -734,7 +737,7 @@ module.exports = NodeHelper.create({
       source = source[s];
     }
 
-    args.per_page = args.per_page || config.maximumEntries;
+    args.per_page = args.per_page || config.flickrResultsPerPage;
     source.getPhotos(args).then(res => {
       resolve(res.body[resultType].photo.map(p => {
         return {

--- a/node_helper.js
+++ b/node_helper.js
@@ -8,7 +8,8 @@ const crypto = require("crypto");
 const http = require("http");
 const https = require("https");
 const Flickr = require("flickr-sdk");
-if (typeof(fetch) === "undefined") {
+const NodeCache = require("node-cache");
+if (typeof (fetch) === "undefined") {
   fetch = require("fetch");
 }
 
@@ -641,6 +642,9 @@ module.exports = NodeHelper.create({
       self.flickr.favorites.getPhotos = self.flickr.favorites.getList;
       self.flickrFeeds = new Flickr.Feeds();
     }
+    if (!self.flickrDataCache) {
+      self.flickrDataCache = new NodeCache();
+    }
 
     const promises = [];
     for (const source of sources) {
@@ -761,6 +765,15 @@ module.exports = NodeHelper.create({
     let pendingRequests = photos.length;
 
     for (let p of photos) {
+      const cacheResult = self.flickrDataCache.get(p.id);
+      if (cacheResult !== undefined) {
+        images.push(cacheResult);
+        if (--pendingRequests === 0) {
+          resolve(images);
+        }
+        continue;
+      }
+
       self.flickr.photos.getSizes({
         photo_id: p.id,
       }).then(res => {
@@ -783,6 +796,7 @@ module.exports = NodeHelper.create({
         if (result.variants.length > 0) {
           result.variants.sort((a, b) => { return a.width * a.height - b.width * b.height; });
           result.url = result.variants[result.variants.length - 1].url;
+          self.flickrDataCache.set(p.id, result, config.flickrDataCacheTime);
           images.push(result);
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "flickr-sdk": "4.0.0"
+        "flickr-sdk": "4.0.0",
+        "node-cache": "^5.1.2"
       }
     },
     "node_modules/asynckit": {
@@ -27,6 +28,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/combined-stream": {
@@ -198,6 +207,17 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.12.0",
@@ -374,6 +394,11 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -492,6 +517,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
     },
     "object-inspect": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/kolbyjack/MMM-Wallpaper#readme",
   "dependencies": {
-    "flickr-sdk": "4.0.0"
+    "flickr-sdk": "4.0.0",
+    "node-cache": "^5.1.2"
   }
 }


### PR DESCRIPTION
Observing that image sizes rarely (if ever) change, we can reduce our load on the API by cacheing the result of the `getSizes` call.

We further reduce the API/bandwidth usage by introducing a config `flickrResultsPerPage`, default to 500 (the API limit).