### PR TITLE
Deduplicate images loaded from multiple Flickr sources

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -655,6 +655,9 @@ module.exports = NodeHelper.create({
       for (const result of results) {
         images.push(...result);
       }
+      // Deduplicate
+      images = [... new Map(images.map(p => [p.id, p])).values()];
+
       // Each source fetches up to maximumImages images (in case some have fewer).
       // Apply shuffle now, as the consumer will truncate.
       if (config.shuffle) {


### PR DESCRIPTION
When multiple Flickr sources are configured, the same photo may appear multiple times (e.g. photostream and album, or in multiple albums). This patch introduces a deduplication filter.