### PR TITLE
Add multiplefolder and subfolder support

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -256,9 +256,7 @@ module.exports = NodeHelper.create({
         console.error("Error in getFiles:", error);
       });
   },
-  
-  // Add this method to your module
-  shuffleArray: function(array) {
+    shuffleArray: function(array) {
     for (let i = array.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [array[i], array[j]] = [array[j], array[i]];


### PR DESCRIPTION
When using `local:` this module only loaded pictures in one folder. This update adds two features:

1. Recursive folder searching
2. Multiple folders support. To use this feature you just need to separate the folders with a comma or a semicolon. It still works with only a single folder. 

Example:

`local:/path/to/picture,/path/to/other/pictures;/another/folder`